### PR TITLE
Add dark mode toggle to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,14 @@
             --shadow-color: rgba(0, 0, 0, 0.08);
             --favorite-color: #ffc107;
         }
+        body.dark-mode {
+            --bg-color: #212529;
+            --card-bg: #343a40;
+            --text-color: #f8f9fa;
+            --secondary-color: #adb5bd;
+            --border-color: #495057;
+            --shadow-color: rgba(0, 0, 0, 0.5);
+        }
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
             margin: 0;
@@ -79,6 +87,23 @@
             transition: background-color 0.2s, color 0.2s;
         }
         #toggle-favorites.active {
+            background-color: var(--primary-color);
+            color: white;
+            border-color: var(--primary-color);
+        }
+
+        #dark-mode-toggle {
+            padding: 1rem 1.5rem;
+            font-size: 1rem;
+            background-color: var(--card-bg);
+            color: var(--secondary-color);
+            border: 1px solid var(--border-color);
+            border-radius: 50px;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: background-color 0.2s, color 0.2s;
+        }
+        #dark-mode-toggle.active {
             background-color: var(--primary-color);
             color: white;
             border-color: var(--primary-color);
@@ -171,6 +196,7 @@
         <section class="filter-section">
             <input type="search" id="search-input" placeholder="프로젝트 이름으로 검색...">
             <button id="toggle-favorites">즐겨찾기 보기</button>
+            <button id="dark-mode-toggle" aria-label="다크 모드 전환">🌙</button>
         </section>
 
         <main class="coin-grid" id="coin-grid">
@@ -229,11 +255,14 @@
         document.addEventListener('DOMContentLoaded', () => {
             const searchInput = document.getElementById('search-input');
             const toggleFavoritesBtn = document.getElementById('toggle-favorites');
+            const darkModeToggle = document.getElementById('dark-mode-toggle');
             const coinGrid = document.getElementById('coin-grid');
             const FAVORITES_KEY = 'cryptoExplorerFavorites';
+            const DARK_MODE_KEY = 'cryptoExplorerDarkMode';
 
             let favorites = getFavorites();
             let favoritesViewActive = false;
+            let darkModeActive = false;
 
             // [중요] 새로운 카드가 추가되었으므로 coinLinks를 다시 조회해야 합니다.
             const coinLinks = Array.from(coinGrid.querySelectorAll('.coin-link'));
@@ -245,6 +274,17 @@
 
             function saveFavorites() {
                 localStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
+            }
+
+            function loadDarkMode() {
+                const stored = localStorage.getItem(DARK_MODE_KEY);
+                darkModeActive = stored === 'true';
+                document.body.classList.toggle('dark-mode', darkModeActive);
+                darkModeToggle.classList.toggle('active', darkModeActive);
+            }
+
+            function saveDarkMode() {
+                localStorage.setItem(DARK_MODE_KEY, darkModeActive);
             }
 
             function toggleFavorite(coinId) {
@@ -307,6 +347,13 @@
 
             searchInput.addEventListener('input', filterCards);
 
+            darkModeToggle.addEventListener('click', () => {
+                darkModeActive = !darkModeActive;
+                document.body.classList.toggle('dark-mode', darkModeActive);
+                darkModeToggle.classList.toggle('active', darkModeActive);
+                saveDarkMode();
+            });
+
             toggleFavoritesBtn.addEventListener('click', () => {
                 favoritesViewActive = !favoritesViewActive;
                 toggleFavoritesBtn.classList.toggle('active', favoritesViewActive);
@@ -315,6 +362,7 @@
             });
 
             updateCardAppearance();
+            loadDarkMode();
         });
     </script>
 


### PR DESCRIPTION
## Summary
- introduce dark mode CSS variables
- add dark mode toggle button and styling
- store preference in localStorage
- apply dark mode state on page load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a452ab258832bae9ae3b0830f5bc5